### PR TITLE
zap2it: Add basic option for language handling

### DIFF
--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -52,6 +52,8 @@ def buildXMLProgram(event,channelId):
 		xml = xml + '      <category>' + sanitizeData(category.replace('filter-','')) + '</category>' + "\n"
 	if event["thumbnail"] is not None:
 		xml = xml + '      <thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
+		xml = xml + '      <icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
+	xml = xml + '      <subtitles type="teletext" />' + "\n"
 	season = "0"
 	episode = "0"
 	episodeid = ""
@@ -70,11 +72,13 @@ def buildXMLProgram(event,channelId):
 		print("no season for:" + event["program"]["title"])
 		
 	#print season + "." + episode
-	if int(season) < 10:
-		season = "0" + str(season)
-	if int(episode) < 10:
-		episode = "0" + str(episode)
-	xml = xml + '      <episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>" + "\n"
+	if ((int(season) != 0) and (int(episode) != 0)):
+		if int(season) < 10:
+			season = "0" + str(season)
+		if int(episode) < 10:
+			episode = "0" + str(episode)
+		xml = xml + '      <episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>" + "\n"
+		xml = xml + '      <episode-num system="common">S' + season + "E" + episode + "</episode-num>" + "\n"
 
 	showid = event["seriesId"].replace('SH','')
 	episodeid = episodeid.replace('EP' + showid,'')

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -53,6 +53,10 @@ def buildXMLProgram(event,channelId):
 	if event["thumbnail"] is not None:
 		xml = xml + '      <thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
 		xml = xml + '      <icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
+	if event["rating"] is not None:
+		xml = xml + '      <rating>' + "\n"
+		xml = xml + '           <value>' + event["rating"] + '</value>' + "\n"
+		xml = xml + '      </rating>' + "\n"
 	xml = xml + '      <subtitles type="teletext" />' + "\n"
 	season = "0"
 	episode = "0"

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -99,7 +99,7 @@ optConfigFile = './xap2itconfig.ini'
 optGuideFile = 'xmlguide.xmltv'
 optLanguage = 'en'
 try:
-    opts, args = getopt.getopt(sys.argv[1:],"hi:o:l:",["ifile=","ofile=","language="])
+	opts, args = getopt.getopt(sys.argv[1:],"hi:o:l:",["ifile=","ofile=","language="])
 except getopt.GetoptError:
 	print("zap2it-GuideScrape.py [-i <inputfile> ] [-o <outputfile>] [-l <language>")
 	sys.exit()

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """
 Forked from https://github.com/daniel-widrick/zap2it-GuideScraping
 All credit goes to daniel-widrick.
@@ -40,12 +41,12 @@ def buildXMLProgram(event,channelId):
 	xml = ""
 	xml = xml + '    <programme start="' + buildXMLDate(event["startTime"]) + '" '
 	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + sanitizeData(channelId) + '">' + "\n"
-	xml = xml + '      <title lang="en">' + sanitizeData(event["program"]["title"]) + '</title>' + "\n"
+	xml = xml + '      <title lang="' + optLanguage + '">' + sanitizeData(event["program"]["title"]) + '</title>' + "\n"
 	if event["program"]["episodeTitle"] is not None:
-		xml = xml + '      <sub-title lang="en">' + sanitizeData(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
+		xml = xml + '      <sub-title lang="' + optLanguage + '">' + sanitizeData(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
-	xml = xml + '      <desc lang="en">' + html.escape(event["program"]["shortDesc"]) + '</desc>' + "\n"
+	xml = xml + '      <desc lang="' + optLanguage + '">' + html.escape(event["program"]["shortDesc"]) + '</desc>' + "\n"
 	xml = xml + '      <length units="minutes">' + sanitizeData(event["duration"]) + '</length>' + "\n"
 	for category in event["filter"]:
 		xml = xml + '      <category>' + sanitizeData(category.replace('filter-','')) + '</category>' + "\n"
@@ -92,10 +93,11 @@ def buildXMLDate(inputDateString):
 #Add Paramter options for config file and guide file
 optConfigFile = './xap2itconfig.ini'
 optGuideFile = 'xmlguide.xmltv'
+optLanguage = 'en'
 try:
-	opts, args = getopt.getopt(sys.argv[1:],"hi:o:",["ifile=","ofile="])
+    opts, args = getopt.getopt(sys.argv[1:],"hi:o:l:",["ifile=","ofile=","language="])
 except getopt.GetoptError:
-	print("zap2it-GuideScrape.py [-i <inputfile> ] [-o <outputfile>]")
+	print("zap2it-GuideScrape.py [-i <inputfile> ] [-o <outputfile>] [-l <language>")
 	sys.exit()
 
 for opt, arg in opts:
@@ -106,6 +108,8 @@ for opt, arg in opts:
 		optConfigFile = arg
 	elif opt in ("-o","--ofile"):
 		optGuideFile = arg
+	elif opt in ("-l","--language"):
+		optLanguage = arg
 
 print("Loading config: ", optConfigFile, " and outputting: ", optGuideFile)
 

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -51,7 +51,7 @@ def buildXMLProgram(event,channelId):
 	for category in event["filter"]:
 		xml = xml + '      <category>' + sanitizeData(category.replace('filter-','')) + '</category>' + "\n"
 	if event["thumbnail"] is not None:
-		xml = xml + '  <thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
+		xml = xml + '      <thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
 	season = "0"
 	episode = "0"
 	episodeid = ""
@@ -74,11 +74,11 @@ def buildXMLProgram(event,channelId):
 		season = "0" + str(season)
 	if int(episode) < 10:
 		episode = "0" + str(episode)
-	xml = xml + '<episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>"
+	xml = xml + '      <episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>" + "\n"
 
 	showid = event["seriesId"].replace('SH','')
 	episodeid = episodeid.replace('EP' + showid,'')
-	xml = xml + '<episode-num system="dd_progid">EP' + sanitizeData(showid + '.' + episodeid) + '</episode-num>'
+	xml = xml + '      <episode-num system="dd_progid">EP' + sanitizeData(showid + '.' + episodeid) + '</episode-num>' + "\n"
 	
 	xml = xml + '    </programme>'+"\n"
 	return xml
@@ -188,14 +188,15 @@ while(closestTimestamp < endTimestamp):
 	addChannels = False
 	closestTimestamp = closestTimestamp + (60*60*3)
 
-guideXML = '<?xml version="1.0" encoding="ISO-8859-1"?>' + "\n"
+guideXML = '<?xml version="1.0" encoding="UTF-8"?>' + "\n"
+guideXML = guideXML + '<!DOCTYPE tv SYSTEM "xmltv.dtd">' + "\n"
 
 guideXML = guideXML + '<tv source-info-url="http://tvlistings.zap2it.com/" source-info-name="zap2it.com" generator-info-name="zap2it-GuideScraping" generator-info-url="daniel@widrick.net">' + "\n"
 
 guideXML = guideXML + channelXML
 guideXML = guideXML + programXML
 
-guideXML = guideXML + "\n" + '</tv>'
+guideXML = guideXML + '</tv>' + "\n"
 
 file = open(optGuideFile,"wb")
 file.write(guideXML.encode('utf8'))


### PR DESCRIPTION
Currently in testing to confirm if this solves the parsing error found in https://github.com/daniel-widrick/zap2it-GuideScraping/issues/9

If this turns out to run OK, a better option would be to define a configuration file with the list of channels that are in other languages than 'en' so that we can parse that at run time and apply the proper language fields where needed.

In the meantime, this simple fix might turn out ok...