### PR TITLE
zap2it: Multiple fixes and added tags

### DIFF
--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -20,36 +20,40 @@ import datetime, os
 
 def buildXMLChannel(channel):
 	xml = ""
-	xml = xml + '    <channel id="' +  html.unescape(channel["channelId"]) + '">' + "\n"
-	xml = xml + '      <display-name>' + html.unescape(channel["channelNo"] + " " + channel["callSign"]) + '</display-name>' + "\n"
-	xml = xml + '      <display-name>' + html.unescape(channel["channelNo"]) + '</display-name>' + "\n"
-	xml = xml + '      <display-name>' + html.unescape(channel["callSign"]) + '</display-name>' + "\n"
-	xml = xml + '    </channel>' + "\n"
+	xml = xml + "\t" + '<channel id="' +  html.unescape(channel["channelId"]) + '">' + "\n"
+	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["channelNo"] + " " + channel["callSign"]) + '</display-name>' + "\n"
+	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["channelNo"]) + '</display-name>' + "\n"
+	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["callSign"]) + '</display-name>' + "\n"
+#	if channel["logoURL"] is not None:
+#		xml = xml + "\t\t" + '<icon src="' + html.unescape(channel["logoURL"]) + '" />' + "\n"
+#	if channel["name"] is not None:
+#		xml = xml + "\t\t" + '<icon src="' + html.unescape(channel["name"]) + '" />' + "\n"
+	xml = xml + "\t" + '</channel>' + "\n"
 	return xml
 
 def buildXMLProgram(event,channelId):
 	#2018-04-11T21:00:00Z
 	#20180408120000 +0000
 	xml = ""
-	xml = xml + '    <programme start="' + buildXMLDate(event["startTime"]) + '" '
+	xml = xml + "\t" + '<programme start="' + buildXMLDate(event["startTime"]) + '" '
 	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + html.unescape(channelId) + '">' + "\n"
-	xml = xml + '      <title lang="' + optLanguage + '">' + html.unescape(event["program"]["title"]) + '</title>' + "\n"
+	xml = xml + "\t\t" + '<title lang="' + optLanguage + '">' + html.unescape(event["program"]["title"]) + '</title>' + "\n"
 	if event["program"]["episodeTitle"] is not None:
-		xml = xml + '      <sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
+		xml = xml + "\t\t" + '<sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
-	xml = xml + '      <desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
-	xml = xml + '      <length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
+	xml = xml + "\t\t" + '<desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
+	xml = xml + "\t\t" + '<length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
 	for category in event["filter"]:
-		xml = xml + '      <category>' + html.unescape(category.replace('filter-','')) + '</category>' + "\n"
+		xml = xml + "\t\t" + '<category>' + html.unescape(category.replace('filter-','')) + '</category>' + "\n"
 	if event["thumbnail"] is not None:
-		xml = xml + '      <thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
-		xml = xml + '      <icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
+		xml = xml + "\t\t" + '<thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
+		xml = xml + "\t\t" + '<icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
 	if event["rating"] is not None:
-		xml = xml + '      <rating>' + "\n"
-		xml = xml + '           <value>' + event["rating"] + '</value>' + "\n"
-		xml = xml + '      </rating>' + "\n"
-	xml = xml + '      <subtitles type="teletext" />' + "\n"
+		xml = xml + "\t\t" + '<rating>' + "\n"
+		xml = xml + "\t\t\t" + '<value>' + event["rating"] + '</value>' + "\n"
+		xml = xml + "\t\t" + '</rating>' + "\n"
+	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
 	season = "0"
 	episode = "0"
 	episodeid = ""
@@ -73,14 +77,14 @@ def buildXMLProgram(event,channelId):
 			season = "0" + str(season)
 		if int(episode) < 10:
 			episode = "0" + str(episode)
-		xml = xml + '      <episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>" + "\n"
-		xml = xml + '      <episode-num system="common">S' + season + "E" + episode + "</episode-num>" + "\n"
+		xml = xml + "\t\t" + '<episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>" + "\n"
+		xml = xml + "\t\t" + '<episode-num system="common">S' + season + "E" + episode + "</episode-num>" + "\n"
 
 	showid = event["seriesId"].replace('SH','')
 	episodeid = episodeid.replace('EP' + showid,'')
-	xml = xml + '      <episode-num system="dd_progid">EP' + html.unescape(showid + '.' + episodeid) + '</episode-num>' + "\n"
+	xml = xml + "\t\t" + '<episode-num system="dd_progid">EP' + html.unescape(showid + '.' + episodeid) + '</episode-num>' + "\n"
 	
-	xml = xml + '    </programme>'+"\n"
+	xml = xml + "\t" + '</programme>'+"\n"
 	return xml
 
 def buildXMLDate(inputDateString):
@@ -189,7 +193,7 @@ while(closestTimestamp < endTimestamp):
 	closestTimestamp = closestTimestamp + (60*60*3)
 
 guideXML = '<?xml version="1.0" encoding="UTF-8"?>' + "\n"
-guideXML = guideXML + '<!DOCTYPE tv SYSTEM "xmltv.dtd">' + "\n"
+guideXML = guideXML + '<!DOCTYPE tv SYSTEM "xmltv.dtd">' + "\n\n"
 
 guideXML = guideXML + '<tv source-info-url="http://tvlistings.zap2it.com/" source-info-name="zap2it.com" generator-info-name="zap2it-GuideScraping" generator-info-url="daniel@widrick.net">' + "\n"
 
@@ -201,6 +205,9 @@ guideXML = guideXML + '</tv>' + "\n"
 file = open(optGuideFile,"wb")
 file.write(guideXML.encode('utf8'))
 file.close()
+#file = open("xmlguide.xmltv.raw","wb")
+#file.write(guide.encode('utf8'))
+#file.close()
 
 #Write a Copy of the file with the current timestamp
 dateTimeObj = datetime.datetime.now()

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -84,6 +84,14 @@ def buildXMLProgram(event,channelId):
 	else:
 		xml = xml + "\t\t" + '<episode-num system="dd_progid">' + event["seriesId"].replace('SH','EP') + '.' + event["program"]["id"][-4:] + '</episode-num>' + "\n"
 
+	for flag in event["flag"]:
+		if (flag == "New"):
+			xml = xml + "\t\t<new />\n"
+		elif (flag == "Finale"):
+			xml = xml + "\t\t<last-chance />\n"
+		elif (flag == "Premiere"):
+			xml = xml + "\t\t<premiere />\n"
+
 	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
 	if event["rating"] is not None:
 		xml = xml + "\t\t" + '<rating>' + "\n"

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -24,10 +24,6 @@ def buildXMLChannel(channel):
 	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["channelNo"] + " " + channel["callSign"]) + '</display-name>' + "\n"
 	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["channelNo"]) + '</display-name>' + "\n"
 	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["callSign"]) + '</display-name>' + "\n"
-#	if channel["logoURL"] is not None:
-#		xml = xml + "\t\t" + '<icon src="' + html.unescape(channel["logoURL"]) + '" />' + "\n"
-#	if channel["name"] is not None:
-#		xml = xml + "\t\t" + '<icon src="' + html.unescape(channel["name"]) + '" />' + "\n"
 	xml = xml + "\t" + '</channel>' + "\n"
 	return xml
 
@@ -39,7 +35,7 @@ def buildXMLProgram(event,channelId):
 	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + html.unescape(channelId) + '">' + "\n"
 	xml = xml + "\t\t" + '<title lang="' + optLanguage + '">' + html.unescape(event["program"]["title"]) + '</title>' + "\n"
 	if event["program"]["episodeTitle"] is not None:
-		xml = xml + "\t\t" + '<sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
+		xml = xml + "\t\t" + '<sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + '</sub-title>' + "\n"
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
 	xml = xml + "\t\t" + '<desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
@@ -203,9 +199,6 @@ guideXML = guideXML + '</tv>' + "\n"
 file = open(optGuideFile,"wb")
 file.write(guideXML.encode('utf8'))
 file.close()
-#file = open("xmlguide.xmltv.raw","wb")
-#file.write(guide.encode('utf8'))
-#file.close()
 
 #Write a Copy of the file with the current timestamp
 dateTimeObj = datetime.datetime.now()

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -43,17 +43,13 @@ def buildXMLProgram(event,channelId):
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
 	xml = xml + "\t\t" + '<desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
-	xml = xml + "\t\t" + '<length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
 	for category in event["filter"]:
 		xml = xml + "\t\t" + '<category>' + html.unescape(category.replace('filter-','')) + '</category>' + "\n"
+	xml = xml + "\t\t" + '<length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
 	if event["thumbnail"] is not None:
 		xml = xml + "\t\t" + '<thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
 		xml = xml + "\t\t" + '<icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
-	if event["rating"] is not None:
-		xml = xml + "\t\t" + '<rating>' + "\n"
-		xml = xml + "\t\t\t" + '<value>' + event["rating"] + '</value>' + "\n"
-		xml = xml + "\t\t" + '</rating>' + "\n"
-	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
+
 	season = "0"
 	episode = "0"
 	episodeid = ""
@@ -83,6 +79,12 @@ def buildXMLProgram(event,channelId):
 	showid = event["seriesId"].replace('SH','')
 	episodeid = episodeid.replace('EP' + showid,'')
 	xml = xml + "\t\t" + '<episode-num system="dd_progid">EP' + html.unescape(showid + '.' + episodeid) + '</episode-num>' + "\n"
+
+	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
+	if event["rating"] is not None:
+		xml = xml + "\t\t" + '<rating>' + "\n"
+		xml = xml + "\t\t\t" + '<value>' + event["rating"] + '</value>' + "\n"
+		xml = xml + "\t\t" + '</rating>' + "\n"
 	
 	xml = xml + "\t" + '</programme>'+"\n"
 	return xml

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -20,12 +20,12 @@ import datetime, os
 
 def sanitizeData(data):
 	#https://stackoverflow.com/questions/1091945/what-characters-do-i-need-to-escape-in-xml-documents
-	sData = data.replace('"','&quot;')
-	sData = sData.replace("'",'&apos;')
-	sData = sData.replace('<','&lt;')
-	sData = sData.replace('<','&gt;')
-	sData = sData.replace('&','&amp;')
-	return sData;
+	data = data.replace('&','&amp;')
+	data = data.replace('"','&quot;')
+	data = data.replace("'",'&apos;')
+	data = data.replace('<','&lt;')
+	data = data.replace('>','&gt;')
+	return data;
 
 def buildXMLChannel(channel):
 	xml = ""
@@ -49,10 +49,10 @@ def buildXMLProgram(event,channelId):
 	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + html.unescape(channelId) + '">' + "\n"
 	xml = xml + "\t\t" + '<title lang="' + optLanguage + '">' + sanitizeData(event["program"]["title"]) + '</title>' + "\n"
 	if event["program"]["episodeTitle"] is not None:
-		xml = xml + "\t\t" + '<sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + '</sub-title>' + "\n"
+		xml = xml + "\t\t" + '<sub-title lang="' + optLanguage + '">' + sanitizeData(event["program"]["episodeTitle"]) + '</sub-title>' + "\n"
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
-	xml = xml + "\t\t" + '<desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
+	xml = xml + "\t\t" + '<desc lang="' + optLanguage + '">' + sanitizeData(event["program"]["shortDesc"]) + '</desc>' + "\n"
 	xml = xml + "\t\t" + '<length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
 	if event["thumbnail"] is not None:
 		xml = xml + "\t\t" + '<thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -18,20 +18,12 @@ import sys, getopt
 #Libraries for historical copies
 import datetime, os
 
-def sanitizeData(data):
-	#https://stackoverflow.com/questions/1091945/what-characters-do-i-need-to-escape-in-xml-documents
-	sData = data.replace('"','&quot;')
-	sData = sData.replace("'",'&apos;')
-	sData = sData.replace('<','&lt;')
-	sData = sData.replace('<','&gt;')
-	sData = sData.replace('&','&amp;')
-	return sData;
 def buildXMLChannel(channel):
 	xml = ""
-	xml = xml + '    <channel id="' +  sanitizeData(channel["channelId"]) + '">' + "\n"
-	xml = xml + '      <display-name>' + sanitizeData(channel["channelNo"] + " " + channel["callSign"]) + '</display-name>' + "\n"
-	xml = xml + '      <display-name>' + sanitizeData(channel["channelNo"]) + '</display-name>' + "\n"
-	xml = xml + '      <display-name>' + sanitizeData(channel["callSign"]) + '</display-name>' + "\n"
+	xml = xml + '    <channel id="' +  html.unescape(channel["channelId"]) + '">' + "\n"
+	xml = xml + '      <display-name>' + html.unescape(channel["channelNo"] + " " + channel["callSign"]) + '</display-name>' + "\n"
+	xml = xml + '      <display-name>' + html.unescape(channel["channelNo"]) + '</display-name>' + "\n"
+	xml = xml + '      <display-name>' + html.unescape(channel["callSign"]) + '</display-name>' + "\n"
 	xml = xml + '    </channel>' + "\n"
 	return xml
 
@@ -40,16 +32,16 @@ def buildXMLProgram(event,channelId):
 	#20180408120000 +0000
 	xml = ""
 	xml = xml + '    <programme start="' + buildXMLDate(event["startTime"]) + '" '
-	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + sanitizeData(channelId) + '">' + "\n"
-	xml = xml + '      <title lang="' + optLanguage + '">' + sanitizeData(event["program"]["title"]) + '</title>' + "\n"
+	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + html.unescape(channelId) + '">' + "\n"
+	xml = xml + '      <title lang="' + optLanguage + '">' + html.unescape(event["program"]["title"]) + '</title>' + "\n"
 	if event["program"]["episodeTitle"] is not None:
-		xml = xml + '      <sub-title lang="' + optLanguage + '">' + sanitizeData(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
+		xml = xml + '      <sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + ' </sub-title>' + "\n"
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
-	xml = xml + '      <desc lang="' + optLanguage + '">' + html.escape(event["program"]["shortDesc"]) + '</desc>' + "\n"
-	xml = xml + '      <length units="minutes">' + sanitizeData(event["duration"]) + '</length>' + "\n"
+	xml = xml + '      <desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
+	xml = xml + '      <length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
 	for category in event["filter"]:
-		xml = xml + '      <category>' + sanitizeData(category.replace('filter-','')) + '</category>' + "\n"
+		xml = xml + '      <category>' + html.unescape(category.replace('filter-','')) + '</category>' + "\n"
 	if event["thumbnail"] is not None:
 		xml = xml + '      <thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
 		xml = xml + '      <icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
@@ -86,7 +78,7 @@ def buildXMLProgram(event,channelId):
 
 	showid = event["seriesId"].replace('SH','')
 	episodeid = episodeid.replace('EP' + showid,'')
-	xml = xml + '      <episode-num system="dd_progid">EP' + sanitizeData(showid + '.' + episodeid) + '</episode-num>' + "\n"
+	xml = xml + '      <episode-num system="dd_progid">EP' + html.unescape(showid + '.' + episodeid) + '</episode-num>' + "\n"
 	
 	xml = xml + '    </programme>'+"\n"
 	return xml

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -69,16 +69,12 @@ def buildXMLProgram(event,channelId):
 		
 	#print season + "." + episode
 	if ((int(season) != 0) and (int(episode) != 0)):
-		if int(season) < 10:
-			season = "0" + str(season)
-		if int(episode) < 10:
-			episode = "0" + str(episode)
-		xml = xml + "\t\t" + '<episode-num system="SxxExx">S' + season + "E" + episode + "</episode-num>" + "\n"
-		xml = xml + "\t\t" + '<episode-num system="common">S' + season + "E" + episode + "</episode-num>" + "\n"
+		xml = xml + "\t\t" + '<episode-num system="common">S' + str(season).zfill(2) + "E" + str(episode).zfill(2) + "</episode-num>" + "\n"
+		xml = xml + "\t\t" + '<episode-num system="xmltv_ns">' + str(int(season) - 1) + "." + str(int(episode) - 1) + ".</episode-num>" + "\n"
 
-	showid = event["seriesId"].replace('SH','')
-	episodeid = episodeid.replace('EP' + showid,'')
-	xml = xml + "\t\t" + '<episode-num system="dd_progid">EP' + html.unescape(showid + '.' + episodeid) + '</episode-num>' + "\n"
+	episodeid = episodeid.replace('EP' + event["seriesId"].replace('SH',''),'')
+	xml = xml + "\t\t" + '<episode-num system="dd_progid">EP' + html.unescape(event["seriesId"].replace('SH','') + '.' + episodeid) + '</episode-num>' + "\n"
+	xml = xml + "\t\t" + '<url>https://tvlistings.zap2it.com//overview.html?programSeriesId=' + event["seriesId"] + '&amp;tmsId=' + event["seriesId"] + episodeid + '</url>' + "\n"
 
 	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
 	if event["rating"] is not None:

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -31,6 +31,9 @@ def buildXMLProgram(event,channelId):
 	#2018-04-11T21:00:00Z
 	#20180408120000 +0000
 	xml = ""
+	season = "0"
+	episode = "0"
+
 	xml = xml + "\t" + '<programme start="' + buildXMLDate(event["startTime"]) + '" '
 	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + html.unescape(channelId) + '">' + "\n"
 	xml = xml + "\t\t" + '<title lang="' + optLanguage + '">' + html.unescape(event["program"]["title"]) + '</title>' + "\n"
@@ -46,9 +49,7 @@ def buildXMLProgram(event,channelId):
 		xml = xml + "\t\t" + '<thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
 		xml = xml + "\t\t" + '<icon src="http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg" />' + "\n"
 
-	season = "0"
-	episode = "0"
-	episodeid = ""
+	xml = xml + "\t\t" + '<url>https://tvlistings.zap2it.com//overview.html?programSeriesId=' + event["seriesId"] + '&amp;tmsId=' + event["program"]["id"] + '</url>' + "\n"
 	
 	try:
 	#if "season" in event:
@@ -57,9 +58,6 @@ def buildXMLProgram(event,channelId):
 		if event["program"]["episode"] is not None:
 			episode = str(event["program"]["episode"])
 
-	#if "id" in event:
-		if event["program"]["id"] is not None:
-			episodeid = str(event["program"]["id"])
 	except KeyError:
 		print("no season for:" + event["program"]["title"])
 		
@@ -68,9 +66,10 @@ def buildXMLProgram(event,channelId):
 		xml = xml + "\t\t" + '<episode-num system="common">S' + str(season).zfill(2) + "E" + str(episode).zfill(2) + "</episode-num>" + "\n"
 		xml = xml + "\t\t" + '<episode-num system="xmltv_ns">' + str(int(season) - 1) + "." + str(int(episode) - 1) + ".</episode-num>" + "\n"
 
-	episodeid = episodeid.replace('EP' + event["seriesId"].replace('SH',''),'')
-	xml = xml + "\t\t" + '<episode-num system="dd_progid">EP' + html.unescape(event["seriesId"].replace('SH','') + '.' + episodeid) + '</episode-num>' + "\n"
-	xml = xml + "\t\t" + '<url>https://tvlistings.zap2it.com//overview.html?programSeriesId=' + event["seriesId"] + '&amp;tmsId=' + event["seriesId"] + episodeid + '</url>' + "\n"
+	if event["program"]["id"][-4:] == "0000":
+		xml = xml + "\t\t" + '<episode-num system="dd_progid">' + event["seriesId"] + '.' + event["program"]["id"][-4:] + '</episode-num>' + "\n"
+	else:
+		xml = xml + "\t\t" + '<episode-num system="dd_progid">' + event["seriesId"].replace('SH','EP') + '.' + event["program"]["id"][-4:] + '</episode-num>' + "\n"
 
 	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
 	if event["rating"] is not None:

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -53,8 +53,6 @@ def buildXMLProgram(event,channelId):
 	if event["program"]["shortDesc"] is None:
 		event["program"]["shortDesc"] = "Unavailable"
 	xml = xml + "\t\t" + '<desc lang="' + optLanguage + '">' + html.unescape(event["program"]["shortDesc"]) + '</desc>' + "\n"
-	for category in event["filter"]:
-		xml = xml + "\t\t" + '<category>' + html.unescape(category.replace('filter-','')) + '</category>' + "\n"
 	xml = xml + "\t\t" + '<length units="minutes">' + html.unescape(event["duration"]) + '</length>' + "\n"
 	if event["thumbnail"] is not None:
 		xml = xml + "\t\t" + '<thumbnail>http://zap2it.tmsimg.com/assets/' + event["thumbnail"] + '.jpg</thumbnail>' + "\n"
@@ -71,9 +69,13 @@ def buildXMLProgram(event,channelId):
 
 	except KeyError:
 		print("no season for:" + event["program"]["title"])
+
+	for category in event["filter"]:
+		xml = xml + "\t\t" + '<category lang="en">' + html.unescape(category.replace('filter-','')) + '</category>' + "\n"
 		
 	#print season + "." + episode
 	if ((int(season) != 0) and (int(episode) != 0)):
+		xml = xml + "\t\t" + '<category lang="en">Series</category>' + "\n"
 		xml = xml + "\t\t" + '<episode-num system="common">S' + str(season).zfill(2) + "E" + str(episode).zfill(2) + "</episode-num>" + "\n"
 		xml = xml + "\t\t" + '<episode-num system="xmltv_ns">' + str(int(season) - 1) + "." + str(int(episode) - 1) + ".</episode-num>" + "\n"
 

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -24,6 +24,8 @@ def buildXMLChannel(channel):
 	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["channelNo"] + " " + channel["callSign"]) + '</display-name>' + "\n"
 	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["channelNo"]) + '</display-name>' + "\n"
 	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["callSign"]) + '</display-name>' + "\n"
+	xml = xml + "\t\t" + '<display-name>' + html.unescape(channel["affiliateName"].title()) + '</display-name>' + "\n"
+	xml = xml + "\t\t" + '<icon src="http:' + channel["thumbnail"].partition('?')[0] + '" />' + "\n"
 	xml = xml + "\t" + '</channel>' + "\n"
 	return xml
 

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -18,6 +18,15 @@ import sys, getopt
 #Libraries for historical copies
 import datetime, os
 
+def sanitizeData(data):
+	#https://stackoverflow.com/questions/1091945/what-characters-do-i-need-to-escape-in-xml-documents
+	sData = data.replace('"','&quot;')
+	sData = sData.replace("'",'&apos;')
+	sData = sData.replace('<','&lt;')
+	sData = sData.replace('<','&gt;')
+	sData = sData.replace('&','&amp;')
+	return sData;
+
 def buildXMLChannel(channel):
 	xml = ""
 	xml = xml + "\t" + '<channel id="' +  html.unescape(channel["channelId"]) + '">' + "\n"
@@ -38,7 +47,7 @@ def buildXMLProgram(event,channelId):
 
 	xml = xml + "\t" + '<programme start="' + buildXMLDate(event["startTime"]) + '" '
 	xml = xml + 'stop="' + buildXMLDate(event["endTime"]) + '" channel="' + html.unescape(channelId) + '">' + "\n"
-	xml = xml + "\t\t" + '<title lang="' + optLanguage + '">' + html.unescape(event["program"]["title"]) + '</title>' + "\n"
+	xml = xml + "\t\t" + '<title lang="' + optLanguage + '">' + sanitizeData(event["program"]["title"]) + '</title>' + "\n"
 	if event["program"]["episodeTitle"] is not None:
 		xml = xml + "\t\t" + '<sub-title lang="' + optLanguage + '">' + html.unescape(event["program"]["episodeTitle"]) + '</sub-title>' + "\n"
 	if event["program"]["shortDesc"] is None:

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -92,7 +92,10 @@ def buildXMLProgram(event,channelId):
 		elif (flag == "Premiere"):
 			xml = xml + "\t\t<premiere />\n"
 
-	xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
+	for tag in event["tags"]:
+		if (tag == "CC"):
+			xml = xml + "\t\t" + '<subtitles type="teletext" />' + "\n"
+
 	if event["rating"] is not None:
 		xml = xml + "\t\t" + '<rating>' + "\n"
 		xml = xml + "\t\t\t" + '<value>' + event["rating"] + '</value>' + "\n"


### PR DESCRIPTION
This patchset does the following
- uses python3 `html.unescape` and allow replacing ALL unneeded characters in all cases
- FIX `sanitizeData(data)` function: was reprocessing `&` at the end causing parsing errors
- uses tabs instead of space delimiters to follow standard
- remove unecessary `episode-num system="SxxExx"`
- fix `episode-num` and add episode URL
- Add channel icon URL
- Add channel real name
- Add Series category when appropriate
- Manage CC tag for `<subtitle` flag