### PR TITLE
Spelling mistake in expected config file

### DIFF
--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -112,7 +112,7 @@ def buildXMLDate(inputDateString):
 	return outputDate
 
 #Add Paramter options for config file and guide file
-optConfigFile = './xap2itconfig.ini'
+optConfigFile = './zap2itconfig.ini'
 optGuideFile = 'xmlguide.xmltv'
 optLanguage = 'en'
 try:


### PR DESCRIPTION
When zap2itconfig.ini.dist is renamed to zap2itconfig.ini to run the script, an error is raised because the script is expecting xap2itconfig.ini instead. Code changed to expect zap2itconfig.ini instead. The difference doesn't really matter but for new users it is unintuitive to have to look through the code and find the expected config file name. Should probably be updated to a command line parameter in the future.