### PR TITLE
Handle channel icon URLs with double slashes

### DIFF
--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -170,7 +170,7 @@ class Zap2ItGuideScrape():
         dispName3 = self.CreateElementWithData("displayName",channel["callSign"])
         dispName4 = self.CreateElementWithData("displayName",channel["affiliateName"].title())
         iconEl = self.guideXML.createElement("icon")
-        iconEl.setAttribute("src","http://"+channel["thumbnail"].partition('?')[0])
+        iconEl.setAttribute("src","http://"+(channel["thumbnail"].partition('?')[0] or "").lstrip('/'))
         channelEl.appendChild(dispName1)
         channelEl.appendChild(dispName2)
         channelEl.appendChild(dispName3)


### PR DESCRIPTION
Hi, I noticed that the URLs for all of the channel icons were coming in with 4 slashes, and my TV front-end was unable to handle the malformed URL to retrieve the icon.

```
<icon src="http:////zap2it.tmsimg.com/h3/NowShowing/11460/s11039_h3_aa.png"/>
```

Turns out that the extra leading slashes were coming directly from the zap2it API. I'm not sure why. But any easy fix is to trim any leading slashes before prepending the `http://`. Seems to work well on my system!

After:
```
<icon src="http://zap2it.tmsimg.com/h3/NowShowing/11460/s11039_h3_aa.png"/>
```