### PR TITLE
Write all channels before programmes in output XML

### DIFF
--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -100,10 +100,11 @@ class Zap2ItGuideScrape():
         print("Load Guide for time: ",str(time))
         response = urllib.request.urlopen(request).read()
         return json.loads(response)
-    def AddResultsToGuide(self,json,addChannels=True):
+    def AddChannelsToGuide(self, json):
         for channel in json["channels"]:
-            if addChannels:
-                self.rootEl.appendChild(self.BuildChannelXML(channel))
+            self.rootEl.appendChild(self.BuildChannelXML(channel))
+    def AddEventsToGuide(self,json):
+        for channel in json["channels"]:
             for event in channel["events"]:
                 self.rootEl.appendChild(self.BuildEventXmL(event,channel["channelId"]))
     def BuildEventXmL(self,event,channelId):
@@ -249,8 +250,10 @@ class Zap2ItGuideScrape():
         loopTime = times[0]
         while(loopTime < times[1]):
             json = self.GetData(loopTime)
-            self.AddResultsToGuide(json,addChannels)
-            addChannels = False
+            if addChannels:
+                self.AddChannelsToGuide(json)     
+                addChannels = False           
+            self.AddEventsToGuide(json)
             loopTime += (60 * 60 * 3)
         self.guideXML.appendChild(self.rootEl)
         self.WriteGuide()


### PR DESCRIPTION
I was having issues using the output of this script with TiviMate, which an IPTV app for Android TV.  As far as I can tell, TiviMate expects all the `<channel>` tags to be before all the `<programme>` tags. I can't know for sure (since it's not open-source), but my suspicion is that TiviMate uses a streaming XML parser and stops parsing once it hits a `<programme>` tag.

I've modified the script to output the `<channel>`s before the `<programme>s`. This seems to resolve the issue in TiviMate, as now I see the EPG for all channels.

Closes #28