### PR TITLE
Fixed typo and added path (.) to docker build example.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,12 +35,11 @@ The 'device' field has also been added to the [lineup] config section and is sup
 </pre>
 
 07-NOV-2022
-Docker isn't my strongest area so I'm not sure of the exact usecase, but I've created a VERY basic Dcokerfile 
+Docker isn't my strongest area so I'm not sure of the exact usecase, but I've created a VERY basic Dockerfile 
 Basic Docker Support:
 Run the following commands from the root of this repo in Windows(PowerShell) or linux:
 <pre>
-docker build -t zap2it:latest
+docker build -t zap2it:latest .
 docker run -v ${PWD}:/guide zap2it
 </pre>
 Running the script like this will read zap2itconfig.ini from the host current directory and output the .xmltv files to the host current directory.
-


### PR DESCRIPTION
Running the guide scraper through Docker, I noticed that the path wasn't present in the Docker build command example in the readme file (see: [Docker example](https://docs.docker.com/engine/reference/commandline/build/#-tag-an-image--t---tag)) . Here is a simple PR which includes that and a minor typo fix. :)

P.S. I recently implemented this guild scraper as part of my Jellyfin media server setup. Thank you - I'm a big fan!