### PR TITLE
Fixed thumbnail url that no longer worked

### DIFF
--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -206,10 +206,11 @@ class Zap2ItGuideScrape():
         programEl.appendChild(lengthEl)
 
         if event["thumbnail"] is not None:
-            thumbnailEl = self.CreateElementWithData("thumbnail","http://zap2it.tmsimg.com/assets/" + event["thumbnail"] + ".jpg")
+            thumbnailUrl = "https://zpmc.tmsimg.com/assets/" + event["thumbnail"] + ".jpg?w=165"
+            thumbnailEl = self.CreateElementWithData("thumbnail", thumbnailUrl)
             programEl.appendChild(thumbnailEl)
             iconEl = self.guideXML.createElement("icon")
-            iconEl.setAttribute("src","http://zap2it.tmsimg.com/assets/" + event["thumbnail"] + ".jpg")
+            iconEl.setAttribute("src", thumbnailUrl)
             programEl.appendChild(iconEl)
 
 

--- a/zap2it-GuideScrape.py
+++ b/zap2it-GuideScrape.py
@@ -205,7 +205,7 @@ class Zap2ItGuideScrape():
         lengthEl.setAttribute("units","minutes")
         programEl.appendChild(lengthEl)
 
-        if event["thumbnail"] is not None:
+        if event["thumbnail"]:
             thumbnailUrl = "https://zpmc.tmsimg.com/assets/" + event["thumbnail"] + ".jpg?w=165"
             thumbnailEl = self.CreateElementWithData("thumbnail", thumbnailUrl)
             programEl.appendChild(thumbnailEl)


### PR DESCRIPTION
The old URL for the thumbnails (http://zap2it.tmsimg.com/assets/) no longer worked. I've replaced that URL with the new one found on gracenotes (https://zpmc.tmsimg.com/assets/). 

I also noticed that the thumbnail check was only checking for None and not the empty string so I changed it to check for None and the empty string to keep a URL from being generated if there is not a thumbnail id provided.